### PR TITLE
enable pass command directly to task

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ngocson2vn/run-ecs-task
+
+go 1.13
+
+require github.com/aws/aws-sdk-go v1.35.7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/aws/aws-sdk-go v1.35.7 h1:FHMhVhyc/9jljgFAcGkQDYjpC9btM0B8VfkLBfctdNE=
+github.com/aws/aws-sdk-go v1.35.7/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/scripts/run-ecs-task.go
+++ b/scripts/run-ecs-task.go
@@ -80,7 +80,7 @@ func main() {
 	handleError(err)
 
 	command := flag.String("command", "", "Command to be executed")
-	passCommandDirectly := flag.Bool("pass_command_directly", false, "true when run command without ls -lc")
+	passCommandDirectly := flag.Bool("pass-command-directly", false, "true when run command without ls -lc")
 	flag.Parse()
 	if command == nil || len(*command) == 0 {
 		handleError(fmt.Errorf("Command is empty. Please specify a command with --command option."))


### PR DESCRIPTION
# Issue
Currently when you pass Command to ECS Task, `"sh", "-l", "-c", *command` will be passed by default.
It is not possible to execute Command without `"sh", "-l", "-c"`. (For example, when ENTRYPOINT is set iin Dockerfile)

# What did I do
- Enable to pass --pass_command_directly flag from command line, and if true, pass --command value into ECS Task.
- default is false
- go.mod file is created so that module will be installed when go build.
- go fmt in scripts/ 
