### PR TITLE
Follow new arn format

### DIFF
--- a/libs/ecs/ecs.go
+++ b/libs/ecs/ecs.go
@@ -316,7 +316,7 @@ func placeTask(ecsSvc *ecs.ECS, task *Task, desiredCount int64) ([]string, error
 
 	taskIDs := []string{}
 	for _, placedTask := range output.Tasks {
-		taskIDs = append(taskIDs, strings.Split(*placedTask.TaskArn, "/")[1])
+		taskIDs = append(taskIDs, strings.Split(*placedTask.TaskArn, "/")[2])
 	}
 
 	return taskIDs, nil


### PR DESCRIPTION
ECS の ARN の format が変わって、task id が正しく取得できなくなったので追従する
https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids

もっといい解決方法はあるが暫定対応